### PR TITLE
Update 0.48b0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
 test:
   imports:
     - opentelemetry.distro
-    - opentelemetry.
+    - opentelemetry.instrumentation
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,10 +37,15 @@ test:
     - pip
 
 about:
-  home: https://pypi.org/project/opentelemetry-distro/
+  home: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro
   summary: OpenTelemetry Python Distro
   license: Apache-2.0
   license_file: LICENSE
+  description: |
+    This package provides entrypoints to configure OpenTelemetry.
+  doc_url: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro
+  dev_url: https://pypi.org/project/opentelemetry-distro/
+
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
     - opentelemetry.instrumentation
   commands:
     - pip check
-    - pytest -v tests
+    - pytest -vv
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ test:
     - pytest -v tests
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,19 @@ source:
   sha256: 5cb15915780ac4972583286a56683d43bd4ca95371d72f5f3f179c8b0b2ddc91
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
   number: 0
+  skip: True # [py<38]
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - hatchling
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
+    - python
     - opentelemetry-api >=1.12,<2.dev0
     - opentelemetry-instrumentation =={{ version }}
     - opentelemetry-sdk >=1.13,<2.dev0
@@ -28,6 +30,7 @@ requirements:
 test:
   imports:
     - opentelemetry.distro
+    - opentelemetry.
   commands:
     - pip check
   requires:
@@ -36,7 +39,7 @@ test:
 about:
   home: https://pypi.org/project/opentelemetry-distro/
   summary: OpenTelemetry Python Distro
-  license: 'Apache-2.0'
+  license: Apache-2.0
   license_file: LICENSE
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,13 +30,10 @@ requirements:
 test:
   imports:
     - opentelemetry.distro
-    - opentelemetry.instrumentation
   commands:
     - pip check
-    - pytest -vv
   requires:
     - pip
-    - pytest
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
     - opentelemetry.instrumentation
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
 
@@ -41,6 +42,7 @@ about:
   summary: OpenTelemetry Python Distro
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
   description: |
     This package provides entrypoints to configure OpenTelemetry.
   doc_url: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro


### PR DESCRIPTION
## ☆ Opentelemetry-distro 0.48b0☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2421)
[Upstream](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro)

### Changes
 - Updated version number and sha256
 - Updated `about` section