### PR TITLE
Update 0.47b0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 
 # Ignore all files and folders in root
 *
-!/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,1 @@
 aggregate_check: False
-channels:
-  - https://staging.continuum.io/prefect/fs/opentelemetry-instrumentation-feedstock/pr3/7413212
-
-
-  

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+aggregate_check: False
+channels:
+  - https://staging.continuum.io/prefect/fs/opentelemetry-instrumentation-feedstock/pr3/7413212
+
+
+  

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,6 @@ requirements:
     - python
     - pip
     - hatchling
-    - setuptools
-    - wheel
   run:
     - python
     - opentelemetry-api >=1.12,<2.dev0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ requirements:
     - opentelemetry-api >=1.12,<2.dev0
     - opentelemetry-instrumentation =={{ version }}
     - opentelemetry-sdk >=1.13,<2.dev0
+  run_constrained:
+    - opentelemetry-exporter-otlp 1.26.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-distro" %}
-{% set version = "0.48b0" %}
+{% set version = "0.47b0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,20 +7,22 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_distro-{{ version }}.tar.gz
-  sha256: 5cb15915780ac4972583286a56683d43bd4ca95371d72f5f3f179c8b0b2ddc91
+  sha256: 715615724bd5c528a2433c0caeb373e4581f8dc7b4bc270179407a1cca0ad99e
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
   number: 0
+  skip: True # [py<38]
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - hatchling
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
+    - python
     - opentelemetry-api >=1.12,<2.dev0
     - opentelemetry-instrumentation =={{ version }}
     - opentelemetry-sdk >=1.13,<2.dev0
@@ -34,10 +36,16 @@ test:
     - pip
 
 about:
-  home: https://pypi.org/project/opentelemetry-distro/
+  home: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro
   summary: OpenTelemetry Python Distro
-  license: 'Apache-2.0'
+  license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
+  description: |
+    This package provides entrypoints to configure OpenTelemetry.
+  doc_url: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro
+  dev_url: https://pypi.org/project/opentelemetry-distro/
+
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
## ☆ Opentelemetry-distro 0.47b0☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-6096)
[Upstream](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro)

### Changes
 - Updated version number and sha256
 - Updated `about` section
 - adding abs.yaml for `opentelemetry-instrumentation` dependency