### PR TITLE
opentelemetry-distro 0.59b0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Ignore all files and folders in root
 *
+!abs.yaml
 !/conda-forge.yml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,50 +1,54 @@
 {% set name = "opentelemetry-distro" %}
-{% set version = "0.48b0" %}
+{% set version = "0.59b0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_distro-{{ version }}.tar.gz
-  sha256: 5cb15915780ac4972583286a56683d43bd4ca95371d72f5f3f179c8b0b2ddc91
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: a72703a514e1773d35d1ec01489a5fd1f1e7ce92e93cf459ba60f85b880d0099
 
 build:
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
   number: 0
   skip: True # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
   host:
-    - python
     - pip
+    - python
     - hatchling
-    - setuptools
-    - wheel
   run:
     - python
-    - opentelemetry-api >=1.12,<2.dev0
     - opentelemetry-instrumentation =={{ version }}
+    - opentelemetry-api >=1.12,<2.dev0
     - opentelemetry-sdk >=1.13,<2.dev0
+  run_constrained:
+    - opentelemetry-exporter-otlp ==1.38.0
 
 test:
+  source_files:
+    - tests
   imports:
     - opentelemetry.distro
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro
-  summary: OpenTelemetry Python Distro
   license: Apache-2.0
   license_file: LICENSE
   license_family: Apache
+  summary: OpenTelemetry Python Distro
   description: |
     This package provides entrypoints to configure OpenTelemetry.
   doc_url: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro
-  dev_url: https://pypi.org/project/opentelemetry-distro/
+  dev_url: https://pypi.org/project/opentelemetry-distro
 
 
 extra:


### PR DESCRIPTION
opentelemetry-distro 0.59b0 

**Destination channel:** Defaults

### Links

- [PKG-10552]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python-contrib/tree/v0.59b0
- conda_forge:    https://github.com/conda-forge/opentelemetry-distro-feedstock
- pypi:           https://pypi.org/project/opentelemetry-distro/0.59b0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-distro/0.59b0

### Explanation of changes:

- new version number


[PKG-10552]: https://anaconda.atlassian.net/browse/PKG-10552